### PR TITLE
Fix wiki URL for example gcode commands

### DIFF
--- a/octoprint_bedlevelvisualizer/templates/bedlevelvisualizer_settings.jinja2
+++ b/octoprint_bedlevelvisualizer/templates/bedlevelvisualizer_settings.jinja2
@@ -10,7 +10,7 @@
 		<div class="tab-content">
 			<div id="bedlevelvisualizer_general" class="tab-pane active">
 				<div class="control-group">
-					<label for="bedlevelvisualizer_command"><i class="icon icon-info-sign" title="GCODE commands to send to printer to retrieve grid data" data-toggle="tooltip"></i> GCODE Commands for Mesh Update Process <small class="muted">Firmware specific examples can be found <a href="https://github.com/jneilliii/OctoPrint-BedLevelVisualizer/wiki/Firmware-Specific-GCODE-Examples" target="_blank">here</a>.</small></label>
+					<label for="bedlevelvisualizer_command"><i class="icon icon-info-sign" title="GCODE commands to send to printer to retrieve grid data" data-toggle="tooltip"></i> GCODE Commands for Mesh Update Process <small class="muted">Firmware specific examples can be found <a href="https://github.com/jneilliii/OctoPrint-BedLevelVisualizer/blob/master/wiki/index.md" target="_blank">here</a>.</small></label>
 					<textarea class="input-block-level" id="bedlevelvisualizer_command" rows="4" data-bind="value: settingsViewModel.settings.plugins.bedlevelvisualizer.command"></textarea>
 				</div>
 				<div class="row-fluid">


### PR DESCRIPTION
The wiki was moved to the /wiki folder in #259, but the link in the settings tab still links to the old location (the github wiki URL). This PR updates the link in the settings tab to this new location (the same URL the redirect on the github wiki points to).